### PR TITLE
[ILVA-81] refactor: BaseFragment 도입으로 Fragment 초기화 패턴 정립 및 ViewModel 관리 방식 개선

### DIFF
--- a/app/src/main/java/com/sangik/iluvbook/base/BaseFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/base/BaseFragment.kt
@@ -16,7 +16,6 @@ import kotlin.reflect.KClass
 abstract class BaseFragment<T : ViewDataBinding, VM : ViewModel>(
     @LayoutRes private val layoutResId: Int,
     private val viewModelClass: KClass<VM>,
-    private val viewModelId: Int = 0 // ViewModel 연결 여부 판단
 ) : Fragment() {
 
     lateinit var binding: T
@@ -31,11 +30,6 @@ abstract class BaseFragment<T : ViewDataBinding, VM : ViewModel>(
         binding = DataBindingUtil.inflate(inflater, layoutResId, container, false)
         binding.lifecycleOwner = viewLifecycleOwner
         binding.setVariable(BR.viewModel, viewModel)
-
-        // ViewModel과 DataBinding 연결 (필요한 경우)
-        if (viewModelId > 0) {
-            binding.setVariable(viewModelId, viewModel)
-        }
 
         initView()
         initObserver()

--- a/app/src/main/java/com/sangik/iluvbook/base/BaseFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/base/BaseFragment.kt
@@ -2,6 +2,7 @@ package com.sangik.iluvbook.base
 
 import android.os.Bundle
 import android.view.LayoutInflater
+import androidx.databinding.library.baseAdapters.BR
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
@@ -14,7 +15,8 @@ import kotlin.reflect.KClass
 
 abstract class BaseFragment<T : ViewDataBinding, VM : ViewModel>(
     @LayoutRes private val layoutResId: Int,
-    private val viewModelClass: KClass<VM>
+    private val viewModelClass: KClass<VM>,
+    private val viewModelId: Int = 0 // ViewModel 연결 여부 판단
 ) : Fragment() {
 
     lateinit var binding: T
@@ -28,6 +30,13 @@ abstract class BaseFragment<T : ViewDataBinding, VM : ViewModel>(
     ): View {
         binding = DataBindingUtil.inflate(inflater, layoutResId, container, false)
         binding.lifecycleOwner = viewLifecycleOwner
+        binding.setVariable(BR.viewModel, viewModel)
+
+        // ViewModel과 DataBinding 연결 (필요한 경우)
+        if (viewModelId > 0) {
+            binding.setVariable(viewModelId, viewModel)
+        }
+
         initView()
         initObserver()
         initListeners()

--- a/app/src/main/java/com/sangik/iluvbook/base/BaseFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/base/BaseFragment.kt
@@ -33,11 +33,11 @@ abstract class BaseFragment<T : ViewDataBinding, VM : ViewModel>(
 
         initView()
         initObserver()
-        initListeners()
+        initListener()
         return binding.root
     }
 
     open fun initView() {}
     open fun initObserver() {}
-    open fun initListeners() {}
+    open fun initListener() {}
 }

--- a/app/src/main/java/com/sangik/iluvbook/base/BaseFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/base/BaseFragment.kt
@@ -2,7 +2,6 @@ package com.sangik.iluvbook.base
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import androidx.databinding.library.baseAdapters.BR
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
@@ -11,6 +10,7 @@ import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.sangik.iluvbook.BR
 import kotlin.reflect.KClass
 
 abstract class BaseFragment<T : ViewDataBinding, VM : ViewModel>(

--- a/app/src/main/java/com/sangik/iluvbook/base/BaseFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/base/BaseFragment.kt
@@ -1,0 +1,40 @@
+package com.sangik.iluvbook.base
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.LayoutRes
+import androidx.databinding.DataBindingUtil
+import androidx.databinding.ViewDataBinding
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import kotlin.reflect.KClass
+
+abstract class BaseFragment<T : ViewDataBinding, VM : ViewModel>(
+    @LayoutRes private val layoutResId: Int,
+    private val viewModelClass: KClass<VM>
+) : Fragment() {
+
+    lateinit var binding: T
+    val viewModel: VM by lazy {
+        ViewModelProvider(this).get(viewModelClass.java)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = DataBindingUtil.inflate(inflater, layoutResId, container, false)
+        binding.lifecycleOwner = viewLifecycleOwner
+        initView()
+        initObserver()
+        initListeners()
+        return binding.root
+    }
+
+    open fun initView() {}
+    open fun initObserver() {}
+    open fun initListeners() {}
+}

--- a/app/src/main/java/com/sangik/iluvbook/fairytale/detail/ui/FairyTaleDetailFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/fairytale/detail/ui/FairyTaleDetailFragment.kt
@@ -26,7 +26,7 @@ class FairyTaleDetailFragment :
         selectionViewModel = ViewModelProvider(requireActivity()).get(FairyTaleSelectionViewModel::class.java)
     }
 
-    override fun initListeners() {
+    override fun initListener() {
         binding.btnLeft.setOnClickListener {
             viewModel.swipeLeft(binding.fairyTaleViewpager)
         }

--- a/app/src/main/java/com/sangik/iluvbook/fairytale/detail/ui/FairyTaleDetailLastPageFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/fairytale/detail/ui/FairyTaleDetailLastPageFragment.kt
@@ -1,46 +1,20 @@
 package com.sangik.iluvbook.fairytale.detail.ui
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
-import androidx.databinding.DataBindingUtil
-import androidx.lifecycle.ViewModelProvider
 import com.sangik.iluvbook.R
+import com.sangik.iluvbook.base.BaseFragment
 import com.sangik.iluvbook.databinding.FragmentFairyTaleDetailLastPageBinding
 import com.sangik.iluvbook.fairytale.detail.viewmodel.FairyTaleLastPageViewModel
-import com.sangik.iluvbook.fairytale.model.dto.Page
 
-class FairyTaleDetailLastPageFragment : Fragment() {
-
-    private lateinit var vm : FairyTaleLastPageViewModel
-    private lateinit var binding : FragmentFairyTaleDetailLastPageBinding
-    override fun onCreate(savedInstanceState: Bundle?) { super.onCreate(savedInstanceState) }
-
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-
-        binding = DataBindingUtil.inflate(
-            inflater, R.layout.fragment_fairy_tale_detail_last_page, container, false
-        )
-        binding.lifecycleOwner = viewLifecycleOwner
-        return binding.root
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        vm = ViewModelProvider(this).get(FairyTaleLastPageViewModel::class.java)
-        binding.lastPageVm = vm
-        setupUi()
-    }
+class FairyTaleDetailLastPageFragment : BaseFragment<FragmentFairyTaleDetailLastPageBinding, FairyTaleLastPageViewModel>(
+    R.layout.fragment_fairy_tale_detail_last_page,
+    FairyTaleLastPageViewModel::class
+) {
+    override fun initView() { setupUi() }
 
     private fun setupUi() {
         val fairyTaleTitle = arguments?.getString("fairyTaleTitle")
-        vm.setTitle(fairyTaleTitle.toString())
+        viewModel.setTitle(fairyTaleTitle.toString())
     }
 
     companion object {

--- a/app/src/main/java/com/sangik/iluvbook/fairytale/detail/ui/FairyTalePageAdapter.kt
+++ b/app/src/main/java/com/sangik/iluvbook/fairytale/detail/ui/FairyTalePageAdapter.kt
@@ -1,6 +1,5 @@
 package com.sangik.iluvbook.fairytale.detail.ui
 
-import android.util.Log
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.sangik.iluvbook.fairytale.detail.viewmodel.FairyTaleDetailViewModel

--- a/app/src/main/java/com/sangik/iluvbook/fairytale/detail/ui/FairyTalePageFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/fairytale/detail/ui/FairyTalePageFragment.kt
@@ -2,12 +2,7 @@ package com.sangik.iluvbook.fairytale.detail.ui
 
 import android.os.Bundle
 import android.speech.tts.TextToSpeech
-import android.util.Log
-import androidx.fragment.app.Fragment
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.ViewModelProvider
 import com.bumptech.glide.Glide
 import com.sangik.iluvbook.R

--- a/app/src/main/java/com/sangik/iluvbook/fairytale/detail/ui/FairyTaleSelectionFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/fairytale/detail/ui/FairyTaleSelectionFragment.kt
@@ -23,7 +23,7 @@
             viewModel.initOptions(options)
         }
 
-        override fun initListeners() {
+        override fun initListener() {
             binding.optionACard.setOnClickListener {
                 viewModel.toggleOptionSelection(0)
             }

--- a/app/src/main/java/com/sangik/iluvbook/fairytale/detail/ui/FairyTaleSelectionFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/fairytale/detail/ui/FairyTaleSelectionFragment.kt
@@ -1,69 +1,52 @@
     package com.sangik.iluvbook.fairytale.detail.ui
 
     import android.os.Bundle
-    import android.util.Log
-    import androidx.fragment.app.Fragment
-    import android.view.LayoutInflater
-    import android.view.View
-    import android.view.ViewGroup
-    import androidx.databinding.DataBindingUtil
     import androidx.lifecycle.ViewModelProvider
     import com.sangik.iluvbook.R
+    import com.sangik.iluvbook.base.BaseFragment
     import com.sangik.iluvbook.databinding.FragmentFairyTaleSelectionBinding
     import com.sangik.iluvbook.fairytale.detail.viewmodel.FairyTaleDetailViewModel
     import com.sangik.iluvbook.fairytale.detail.viewmodel.FairyTaleSelectionViewModel
     import com.sangik.iluvbook.fairytale.model.dto.FairyTaleOption
     import com.sangik.iluvbook.fairytale.model.dto.OptionUserSelected
 
-    class FairyTaleSelectionFragment : Fragment() {
-        private lateinit var selectionViewModel : FairyTaleSelectionViewModel
+    class FairyTaleSelectionFragment : BaseFragment<FragmentFairyTaleSelectionBinding, FairyTaleSelectionViewModel>(
+        R.layout.fragment_fairy_tale_selection,
+        FairyTaleSelectionViewModel::class
+    ) {
         private lateinit var detailViewModel : FairyTaleDetailViewModel
-        private lateinit var binding : FragmentFairyTaleSelectionBinding
         private lateinit var options: List<FairyTaleOption>
 
-        override fun onCreate(savedInstanceState: Bundle?) {
-            super.onCreate(savedInstanceState)
+        override fun initView() {
             options = arguments?.getParcelableArrayList(ARG_OPTION) ?: emptyList()
             detailViewModel = ViewModelProvider(requireActivity()).get(FairyTaleDetailViewModel::class.java)
-            selectionViewModel = ViewModelProvider(requireActivity()).get(FairyTaleSelectionViewModel::class.java)
-            selectionViewModel.initOptions(options)
+            viewModel.initOptions(options)
         }
 
-        override fun onCreateView(
-            inflater: LayoutInflater, container: ViewGroup?,
-            savedInstanceState: Bundle?
-        ): View {
-
-            binding = DataBindingUtil.inflate(
-                inflater, R.layout.fragment_fairy_tale_selection, container, false
-            )
-
-            binding.selectionViewModel = selectionViewModel
-
-            binding.lifecycleOwner = viewLifecycleOwner
-
-            observeSelectionViewModel()
-            return binding.root
+        override fun initListeners() {
+            binding.optionACard.setOnClickListener {
+                viewModel.toggleOptionSelection(0)
+            }
+            binding.optionBCard.setOnClickListener {
+                viewModel.toggleOptionSelection(1)
+            }
+            binding.optionCCard.setOnClickListener {
+                viewModel.toggleOptionSelection(2)
+            }
         }
 
-        override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-            super.onViewCreated(view, savedInstanceState)
-
-            initListener()
-        }
-
-        private fun observeSelectionViewModel() {
+        override fun initObserver() {
             // 옵션 카드 상태 변경
-            selectionViewModel.selectedOptionIndex.observe(viewLifecycleOwner) { selectedIndex ->
+            viewModel.selectedOptionIndex.observe(viewLifecycleOwner) { selectedIndex ->
                 updateOptionCardBackgrounds(selectedIndex)
                 setUserSelectedOption(selectedIndex)
             }
 
             // 사용자 선택 후 새 동화 관련 Response Observing
-            selectionViewModel.fairyTaleSelectionResponseList.observe(viewLifecycleOwner) { response ->
+            viewModel.fairyTaleSelectionResponseList.observe(viewLifecycleOwner) { response ->
                 response?.let {
                     if (it.isNotEmpty()) {
-                        selectionViewModel.setupNewSelectionOption(it.last())
+                        viewModel.setupNewSelectionOption(it.last())
                     }
                 }
             }
@@ -75,9 +58,9 @@
 
                 // 번역된 옵션 내용 설정
                 val translatedContent = when (selectedIndex) {
-                    0 -> selectionViewModel.optionATranslated.value ?: ""
-                    1 -> selectionViewModel.optionBTranslated.value ?: ""
-                    2 -> selectionViewModel.optionCTranslated.value ?: ""
+                    0 -> viewModel.optionATranslated.value ?: ""
+                    1 -> viewModel.optionBTranslated.value ?: ""
+                    2 -> viewModel.optionCTranslated.value ?: ""
                     else -> ""
                 }
 
@@ -103,19 +86,6 @@
             )
         }
 
-        private fun initListener() {
-            binding.apply {
-                optionACard.setOnClickListener {
-                    selectionViewModel?.toggleOptionSelection(0)
-                }
-                optionBCard.setOnClickListener {
-                    selectionViewModel?.toggleOptionSelection(1)
-                }
-                optionCCard.setOnClickListener {
-                    selectionViewModel?.toggleOptionSelection(2)
-                }
-            }
-        }
         companion object {
             private const val ARG_OPTION = "options"
 

--- a/app/src/main/java/com/sangik/iluvbook/fairytale/intro/ui/FairyTaleIntroFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/fairytale/intro/ui/FairyTaleIntroFragment.kt
@@ -1,61 +1,42 @@
 package com.sangik.iluvbook.fairytale.intro.ui
 
-import android.os.Bundle
-import androidx.fragment.app.Fragment
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
 import com.sangik.iluvbook.R
+import com.sangik.iluvbook.base.BaseFragment
 import com.sangik.iluvbook.databinding.FragmentFairyTaleIntroBinding
 import com.sangik.iluvbook.fairytale.intro.viewmodel.FairyTaleIntroViewModel
 import com.sangik.iluvbook.hangman.intro.viewmodel.IntroHangmanViewModel
 
-class FairyTaleIntroFragment : Fragment() {
-    private lateinit var vm: FairyTaleIntroViewModel
+class FairyTaleIntroFragment : BaseFragment<FragmentFairyTaleIntroBinding, FairyTaleIntroViewModel>(
+    R.layout.fragment_fairy_tale_intro,
+    FairyTaleIntroViewModel::class
+) {
     private lateinit var introHangmanViewModel : IntroHangmanViewModel
-    private lateinit var binding: FragmentFairyTaleIntroBinding
     private val args : FairyTaleIntroFragmentArgs by navArgs()
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        binding = DataBindingUtil.inflate(
-            inflater, R.layout.fragment_fairy_tale_intro, container, false
-        )
 
-        // ViewModel 초기화
-        vm = ViewModelProvider(this).get(FairyTaleIntroViewModel::class.java)
+    override fun initView() {
         introHangmanViewModel = ViewModelProvider(requireActivity()).get(IntroHangmanViewModel::class.java)
-
-        binding.lifecycleOwner = viewLifecycleOwner
-        binding.fairyTaleIntroViewModel = vm
-
-        observeIntroHangmanViewModel()
-        return binding.root
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
 
         // RecyclerView 설정
         setRecyclerView(args.keywords.toList())
 
         // 썸네일 이미지 설정
         setGlideImage()
-
-        initListener()
     }
 
-    private fun initListener() {
-        // 동화 상세로 navigate
+    override fun initObserver() {
+        observeIntroHangmanViewModel()
+    }
+
+    override fun initListeners() {
         actionToFairyTaleDetail()
     }
+
 
     private fun actionToFairyTaleDetail() {
         binding.btnReadFairytale.setOnClickListener {
@@ -67,14 +48,14 @@ class FairyTaleIntroFragment : Fragment() {
         // 동화 Response observe
         introHangmanViewModel.fairyTaleResponse.observe(viewLifecycleOwner) { response ->
             response?.let {
-                vm.initData(response.title, response.summary, response.pages.first().imgURL)
+                viewModel.initData(response.title, response.summary, response.pages.first().imgURL)
             }
         }
 
         // 선택형 동화 Response observe
         introHangmanViewModel.fairyTaleSelectionResponse.observe(viewLifecycleOwner) { response ->
             response?.let {
-                vm.initData(response.title, "", response.imgURL)
+                viewModel.initData(response.title, "", response.imgURL)
                 binding.fairytaleIntroSummary.visibility = View.GONE
             }
         }
@@ -82,7 +63,7 @@ class FairyTaleIntroFragment : Fragment() {
 
     // 썸네일 이미지 설정
     private fun setGlideImage() {
-        vm.fairyTaleImgUrl.observe(viewLifecycleOwner) {
+        viewModel.fairyTaleImgUrl.observe(viewLifecycleOwner) {
             it.let {
                 Glide.with(this)
                     .load(it)

--- a/app/src/main/java/com/sangik/iluvbook/fairytale/intro/ui/FairyTaleIntroFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/fairytale/intro/ui/FairyTaleIntroFragment.kt
@@ -33,7 +33,7 @@ class FairyTaleIntroFragment : BaseFragment<FragmentFairyTaleIntroBinding, Fairy
         observeIntroHangmanViewModel()
     }
 
-    override fun initListeners() {
+    override fun initListener() {
         actionToFairyTaleDetail()
     }
 

--- a/app/src/main/java/com/sangik/iluvbook/fairytale/loading/ui/FairyTaleLoadingFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/fairytale/loading/ui/FairyTaleLoadingFragment.kt
@@ -1,59 +1,33 @@
 package com.sangik.iluvbook.fairytale.loading.ui
 
-import android.os.Bundle
-import androidx.fragment.app.Fragment
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
 import androidx.constraintlayout.widget.ConstraintSet
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.transition.TransitionManager
 import com.sangik.iluvbook.R
+import com.sangik.iluvbook.base.BaseFragment
 import com.sangik.iluvbook.databinding.FragmentFairyTaleLoadingBinding
 import com.sangik.iluvbook.fairytale.loading.viewmodel.FairyTaleLoadingViewModel
 import com.sangik.iluvbook.hangman.intro.viewmodel.IntroHangmanViewModel
 
-class FairyTaleLoadingFragment : Fragment() {
-    private lateinit var binding: FragmentFairyTaleLoadingBinding
-    private lateinit var fairyTaleLoadingViewModel: FairyTaleLoadingViewModel
+class FairyTaleLoadingFragment : BaseFragment<FragmentFairyTaleLoadingBinding, FairyTaleLoadingViewModel>(
+    R.layout.fragment_fairy_tale_loading,
+    FairyTaleLoadingViewModel::class
+) {
     private lateinit var introViewModel: IntroHangmanViewModel
     private val args: FairyTaleLoadingFragmentArgs by navArgs()
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        fairyTaleLoadingViewModel = ViewModelProvider(this).get(FairyTaleLoadingViewModel::class.java)
 
+    override fun initView() {
         introViewModel = ViewModelProvider(requireActivity()).get(IntroHangmanViewModel::class.java)
-
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_fairy_tale_loading,
-            container,
-            false
-        )
-        binding.lifecycleOwner = viewLifecycleOwner
-        binding.loadingViewModel = fairyTaleLoadingViewModel
-
-        return binding.root
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        initListener()
+    override fun initObserver() {
         observeIntroViewModel()
-        observeLoadingState() // 상태 관찰 시작
+        observeLoadingState()
     }
 
-    private fun initListener() {
+    override fun initListener() {
         binding.btnReadFairytale.setOnClickListener {
             handleFairyTaleIntroNavigation()
         }
@@ -64,12 +38,12 @@ class FairyTaleLoadingFragment : Fragment() {
         introViewModel.apply {
             fairyTaleResponse.observe(viewLifecycleOwner) { response ->
                 response?.let {
-                    fairyTaleLoadingViewModel.updateLoadingState() // 동화 생성 완료 UI로 업데이트
+                    viewModel.updateLoadingState() // 동화 생성 완료 UI로 업데이트
                 }
             }
             fairyTaleSelectionResponse.observe(viewLifecycleOwner) { response ->
                 response?.let {
-                    fairyTaleLoadingViewModel.updateLoadingState()
+                    viewModel.updateLoadingState()
                 }
             }
         }
@@ -77,7 +51,7 @@ class FairyTaleLoadingFragment : Fragment() {
 
     // 로딩 상태 변화 관찰
     private fun observeLoadingState() {
-        fairyTaleLoadingViewModel.isLoadingCompleted.observe(viewLifecycleOwner) { isCompleted ->
+        viewModel.isLoadingCompleted.observe(viewLifecycleOwner) { isCompleted ->
             if (isCompleted) {
                 updateLoadingBannerUi() // 제약 조건 및 애니메이션 적용
             }

--- a/app/src/main/java/com/sangik/iluvbook/fairytale/onboarding/ui/OnboardingFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/fairytale/onboarding/ui/OnboardingFragment.kt
@@ -1,43 +1,17 @@
 package com.sangik.iluvbook.fairytale.onboarding.ui
 
-import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
-import androidx.databinding.DataBindingUtil
-import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
 import com.sangik.iluvbook.R
+import com.sangik.iluvbook.base.BaseFragment
 import com.sangik.iluvbook.databinding.FragmentOnboardingBinding
 import com.sangik.iluvbook.fairytale.onboarding.viewmodel.OnboardingViewModel
 
-class OnboardingFragment : Fragment() {
-    private lateinit var vm : OnboardingViewModel
+class OnboardingFragment : BaseFragment<FragmentOnboardingBinding, OnboardingViewModel>(
+    R.layout.fragment_onboarding,
+    OnboardingViewModel::class
+) {
 
-    private lateinit var binding : FragmentOnboardingBinding
-
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        vm = ViewModelProvider(requireActivity()).get(OnboardingViewModel::class.java)
-
-        binding = DataBindingUtil.inflate<FragmentOnboardingBinding?>(
-            inflater, R.layout.fragment_onboarding, container, false
-        ).apply {
-            lifecycleOwner = viewLifecycleOwner
-            onboardingViewModel = vm
-        }
-        return binding.root
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        initListener()
-    }
-
-    private fun initListener() {
+    override fun initListener() {
         with(binding) {
             btnLow.setOnClickListener{ navigateToFairyTaleCreationFragment("low") } // 난이도 선택 : 영유아
             btnMid.setOnClickListener{ navigateToFairyTaleCreationFragment("mid") } // 난이도 선택 : 초등학교 저학년
@@ -49,5 +23,4 @@ class OnboardingFragment : Fragment() {
             .actionOnboardingFragmentToFairyTaleCreationFragment(selectedLevel)
         findNavController().navigate(actionToFairyTaleCreation)
     }
-
 }

--- a/app/src/main/java/com/sangik/iluvbook/hangman/game/ui/HangmanFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/hangman/game/ui/HangmanFragment.kt
@@ -6,7 +6,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.widget.TextView
 import androidx.core.content.ContextCompat
-import androidx.databinding.library.baseAdapters.BR
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
@@ -23,7 +22,6 @@ import kotlinx.coroutines.launch
 class HangmanFragment : BaseFragment<FragmentHangmanBinding, HangmanViewModel> (
     R.layout.fragment_hangman,
     HangmanViewModel::class,
-    BR.viewModel
 ) {
     private lateinit var sharedIntroViewModel: IntroHangmanViewModel
     private val args: HangmanFragmentArgs by navArgs()

--- a/app/src/main/java/com/sangik/iluvbook/hangman/game/ui/HangmanFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/hangman/game/ui/HangmanFragment.kt
@@ -2,18 +2,16 @@ package com.sangik.iluvbook.hangman.game.ui
 
 import android.graphics.Color
 import android.os.Bundle
-import android.util.Log
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.TextView
 import androidx.core.content.ContextCompat
-import androidx.databinding.DataBindingUtil
+import androidx.databinding.library.baseAdapters.BR
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.sangik.iluvbook.R
+import com.sangik.iluvbook.base.BaseFragment
 import com.sangik.iluvbook.databinding.FragmentHangmanBinding
 import com.sangik.iluvbook.hangman.game.viewmodel.HangmanViewModel
 import com.sangik.iluvbook.hangman.intro.viewmodel.IntroHangmanViewModel
@@ -22,45 +20,33 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-class HangmanFragment : Fragment() {
-    private lateinit var hangmanViewModel: HangmanViewModel
-    private lateinit var introViewModel: IntroHangmanViewModel
-    private lateinit var binding: FragmentHangmanBinding
+class HangmanFragment : BaseFragment<FragmentHangmanBinding, HangmanViewModel> (
+    R.layout.fragment_hangman,
+    HangmanViewModel::class,
+    BR.viewModel
+) {
+    private lateinit var sharedIntroViewModel: IntroHangmanViewModel
     private val args: HangmanFragmentArgs by navArgs()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        hangmanViewModel = ViewModelProvider(this).get(HangmanViewModel::class.java)
-        introViewModel = ViewModelProvider(requireActivity()).get(IntroHangmanViewModel::class.java)
+        sharedIntroViewModel = ViewModelProvider(requireActivity()).get(IntroHangmanViewModel::class.java)
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_hangman, container, false)
-        binding.lifecycleOwner = viewLifecycleOwner
-        binding.hangmanViewModel = hangmanViewModel
-
+    override fun initView() {
         setupKeyboard()
-        observeHangmanViewModel()
-
-        return binding.root
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
+    override fun initObserver() {
         observeIntroViewModel()
-        initListener()
+        observeHangmanViewModel()
     }
 
-
-    private fun initListener() {
+    override fun initListeners() {
         binding.btnMoveFairytale.setOnClickListener {
             navigateToFairyTaleDetail()
         }
     }
-
     // 동화 상세로 이동
     private fun navigateToFairyTaleDetail() {
         val actionFairyTaleIntro = HangmanFragmentDirections
@@ -76,24 +62,21 @@ class HangmanFragment : Fragment() {
     }
 
     private fun observeIntroViewModel() {
-        introViewModel.apply {
+        sharedIntroViewModel.apply {
             hangmanResponse.observe(viewLifecycleOwner) { response ->
                 response?.let {
-                    hangmanViewModel.setHangmanData(response.word, response.hint) // 행맨 데이터 세팅
+                    viewModel.setHangmanData(response.word, response.hint) // 행맨 데이터 세팅
                     initInput(response.word) // 사용자 입력칸 생성
                 }
             }
-
             fairyTaleResponse.observe(viewLifecycleOwner) { response ->
                 response?.let { enableMoveFairyTaleButton() }
             }
-
             fairyTaleSelectionResponse.observe(viewLifecycleOwner) {
                 response -> response?.let { enableMoveFairyTaleButton() }
             }
         }
     }
-
     private fun enableMoveFairyTaleButton() {
         binding.btnMoveFairytale.let {
             it.setBackgroundResource(R.drawable.btn_move_fairytale)
@@ -102,7 +85,7 @@ class HangmanFragment : Fragment() {
     }
     // LiveData 관찰
     private fun observeHangmanViewModel() {
-        hangmanViewModel.apply {
+        viewModel.apply {
             answer.observe(viewLifecycleOwner) { answer ->
                 initInput(answer)
             }
@@ -119,7 +102,7 @@ class HangmanFragment : Fragment() {
             // 게임 완료, 동화 응답이 오지 않았을 때 2초 후 FairyTaleLoading으로 이동
             isGameEnd.observe(viewLifecycleOwner) { isGameEnd ->
                 if (isGameEnd) {
-                    if (introViewModel.fairyTaleResponse.value == null) {
+                    if (sharedIntroViewModel.fairyTaleResponse.value == null) {
                         CoroutineScope(Dispatchers.Main).launch {
                             delay(2000)
                             navigateToFairyTaleLoading()
@@ -156,7 +139,7 @@ class HangmanFragment : Fragment() {
 
     // 키보드에 표시될 문자 관찰
     private fun setupKeyboard() {
-        hangmanViewModel.keyboardChars.observe(viewLifecycleOwner) { chars ->
+        viewModel.keyboardChars.observe(viewLifecycleOwner) { chars ->
                 initKeyboard(chars)
         }
     }
@@ -173,7 +156,7 @@ class HangmanFragment : Fragment() {
 
             keyCapText.text = char.toString()
             keyCapText.setOnClickListener {
-                hangmanViewModel.onKeyClicked(char) // 글자 선택 했을 때 정의
+                viewModel.onKeyClicked(char) // 글자 선택 했을 때 정의
                 keyCapText.apply {
                     setBackgroundColor(Color.TRANSPARENT)
                     setTextColor(

--- a/app/src/main/java/com/sangik/iluvbook/hangman/game/ui/HangmanFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/hangman/game/ui/HangmanFragment.kt
@@ -40,7 +40,7 @@ class HangmanFragment : BaseFragment<FragmentHangmanBinding, HangmanViewModel> (
         observeHangmanViewModel()
     }
 
-    override fun initListeners() {
+    override fun initListener() {
         binding.btnMoveFairytale.setOnClickListener {
             navigateToFairyTaleDetail()
         }

--- a/app/src/main/java/com/sangik/iluvbook/hangman/intro/ui/IntroHangmanFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/hangman/intro/ui/IntroHangmanFragment.kt
@@ -1,6 +1,7 @@
 package com.sangik.iluvbook.hangman.intro.ui
 
 import android.os.Bundle
+import androidx.databinding.library.baseAdapters.BR
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
@@ -11,7 +12,8 @@ import com.sangik.iluvbook.hangman.intro.viewmodel.IntroHangmanViewModel
 
 class IntroHangmanFragment : BaseFragment<FragmentIntroHangmanBinding, IntroHangmanViewModel>(
     R.layout.fragment_intro_hangman,
-    IntroHangmanViewModel::class
+    IntroHangmanViewModel::class,
+    BR.viewModel
 ) {
 
     private val args: IntroHangmanFragmentArgs by navArgs()
@@ -34,7 +36,7 @@ class IntroHangmanFragment : BaseFragment<FragmentIntroHangmanBinding, IntroHang
         // Premium 여부 설정
         sharedViewModel.setIsPremium(args.isPremium)
 
-        // Keywords 설정
+        // keywords 설정
         sharedViewModel.setKeywords(args.keywords)
 
         // 행맨, 동화 API 호출

--- a/app/src/main/java/com/sangik/iluvbook/hangman/intro/ui/IntroHangmanFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/hangman/intro/ui/IntroHangmanFragment.kt
@@ -13,7 +13,6 @@ import com.sangik.iluvbook.hangman.intro.viewmodel.IntroHangmanViewModel
 class IntroHangmanFragment : BaseFragment<FragmentIntroHangmanBinding, IntroHangmanViewModel>(
     R.layout.fragment_intro_hangman,
     IntroHangmanViewModel::class,
-    BR.viewModel
 ) {
 
     private val args: IntroHangmanFragmentArgs by navArgs()

--- a/app/src/main/java/com/sangik/iluvbook/hangman/intro/ui/IntroHangmanFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/hangman/intro/ui/IntroHangmanFragment.kt
@@ -1,72 +1,55 @@
 package com.sangik.iluvbook.hangman.intro.ui
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.sangik.iluvbook.R
+import com.sangik.iluvbook.base.BaseFragment
 import com.sangik.iluvbook.databinding.FragmentIntroHangmanBinding
-import com.sangik.iluvbook.fairytale.model.dto.Keywords
 import com.sangik.iluvbook.hangman.intro.viewmodel.IntroHangmanViewModel
-class IntroHangmanFragment : Fragment() {
 
-    private lateinit var vm : IntroHangmanViewModel
-    private lateinit var binding : FragmentIntroHangmanBinding
+class IntroHangmanFragment : BaseFragment<FragmentIntroHangmanBinding, IntroHangmanViewModel>(
+    R.layout.fragment_intro_hangman,
+    IntroHangmanViewModel::class
+) {
+
     private val args: IntroHangmanFragmentArgs by navArgs()
+    private lateinit var sharedViewModel: IntroHangmanViewModel
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        vm = ViewModelProvider(requireActivity()).get(IntroHangmanViewModel::class.java)
+        sharedViewModel = ViewModelProvider(requireActivity()).get(IntroHangmanViewModel::class.java)
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-
-        binding = DataBindingUtil.inflate(
-            inflater, R.layout.fragment_intro_hangman, container, false
-        )
-
-        setupKeywords()
-        initIsPremiumStatus()
-        generateHangmanAndFairyTale()
-        initListener()
-
-        return binding.root
+    override fun initView() {
+        initializeData()
     }
 
-    private fun initIsPremiumStatus() {
-        vm.setIsPremium(args.isPremium)
+    override fun initListeners() {
+        binding.btnStartGame.setOnClickListener { navigateToHangmanFragment() }
     }
 
-    // 사용자 선택 keywords 설정
-    private fun setupKeywords() {
-        vm.setKeywords(args.keywords)
-    }
+    private fun initializeData() {
+        // Premium 여부 설정
+        sharedViewModel.setIsPremium(args.isPremium)
 
-    private fun initListener() {
-        binding.btnStartGame.setOnClickListener {
-            val allKeywords = vm.integrateKeywords().toTypedArray()
-            val introHangmanAction = IntroHangmanFragmentDirections.actionIntroHangmanFragmentToHangmanFragment(allKeywords)
-            findNavController().navigate(introHangmanAction)
-        }
-    }
+        // Keywords 설정
+        sharedViewModel.setKeywords(args.keywords)
 
-
-    private fun generateHangmanAndFairyTale() {
-        vm.callHangmanAndFairyTaleApi(
+        // 행맨, 동화 API 호출
+        sharedViewModel.callHangmanAndFairyTaleApi(
             traits = args.keywords.traits,
             characters = args.keywords.characters,
             settings = args.keywords.settings,
             genre = args.keywords.genre,
             level = args.level,
-            args.isPremium
+            isPremium = args.isPremium
         )
     }
+    private fun navigateToHangmanFragment() {
+        val allKeywords = sharedViewModel.integrateKeywords().toTypedArray()
+        val action = IntroHangmanFragmentDirections.actionIntroHangmanFragmentToHangmanFragment(allKeywords)
+        findNavController().navigate(action)
+    }
 }
-

--- a/app/src/main/java/com/sangik/iluvbook/hangman/intro/ui/IntroHangmanFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/hangman/intro/ui/IntroHangmanFragment.kt
@@ -27,7 +27,7 @@ class IntroHangmanFragment : BaseFragment<FragmentIntroHangmanBinding, IntroHang
         initializeData()
     }
 
-    override fun initListeners() {
+    override fun initListener() {
         binding.btnStartGame.setOnClickListener { navigateToHangmanFragment() }
     }
 

--- a/app/src/main/java/com/sangik/iluvbook/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/home/ui/HomeFragment.kt
@@ -1,40 +1,25 @@
 package com.sangik.iluvbook.home.ui
 
-import android.content.Intent
-import android.os.Bundle
-import androidx.fragment.app.Fragment
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
-import androidx.fragment.app.viewModels
-import androidx.navigation.Navigation
+import androidx.databinding.library.baseAdapters.BR
 import androidx.navigation.fragment.findNavController
 import com.sangik.iluvbook.R
+import com.sangik.iluvbook.base.BaseFragment
 import com.sangik.iluvbook.databinding.FragmentHomeBinding
 import com.sangik.iluvbook.home.viewmodel.HomeViewModel
-import com.sangik.iluvbook.fairytale.onboarding.ui.OnboardingFragment
 
-class HomeFragment : Fragment() {
-    private lateinit var binding: FragmentHomeBinding
-    private val homeViewModel: HomeViewModel by viewModels()
-    override fun onCreate(savedInstanceState: Bundle?) { super.onCreate(savedInstanceState) }
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        binding = FragmentHomeBinding.inflate(inflater, container, false)
-        binding.homeViewModel = homeViewModel
-        binding.lifecycleOwner = viewLifecycleOwner
+class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(
+    R.layout.fragment_home,
+    HomeViewModel::class,
+    BR.viewModel
+) {
 
-        initObserver()
+    override fun initView() {}
 
-        return binding.root
-    }
-    private fun initObserver() {
-        homeViewModel.navigateToOnboarding.observe(viewLifecycleOwner) { navigate ->
+    override fun initObserver() {
+        viewModel.navigateToOnboarding.observe(viewLifecycleOwner) { navigate ->
             if (navigate) {
                 findNavController().navigate(R.id.action_homeFragment_to_onboardingFragment)
-                homeViewModel.onNavigateToOnBoarding()
+                viewModel.onNavigateToOnBoarding()
             }
         }
     }

--- a/app/src/main/java/com/sangik/iluvbook/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/sangik/iluvbook/home/ui/HomeFragment.kt
@@ -1,6 +1,5 @@
 package com.sangik.iluvbook.home.ui
 
-import androidx.databinding.library.baseAdapters.BR
 import androidx.navigation.fragment.findNavController
 import com.sangik.iluvbook.R
 import com.sangik.iluvbook.base.BaseFragment
@@ -10,7 +9,6 @@ import com.sangik.iluvbook.home.viewmodel.HomeViewModel
 class HomeFragment : BaseFragment<FragmentHomeBinding, HomeViewModel>(
     R.layout.fragment_home,
     HomeViewModel::class,
-    BR.viewModel
 ) {
 
     override fun initView() {}

--- a/app/src/main/res/layout/fragment_fairy_tale_creation.xml
+++ b/app/src/main/res/layout/fragment_fairy_tale_creation.xml
@@ -6,7 +6,7 @@
 
     <data>
         <variable
-            name="fairyTaleCreationViewModel"
+            name="viewModel"
             type="com.sangik.iluvbook.fairytale.creation.viewmodel.FairyTaleCreationViewModel"/>
     </data>
 
@@ -127,8 +127,8 @@
                                     android:layout_width="37dp"
                                     android:layout_height="37dp"
                                     android:layout_marginEnd="4dp"
-                                    android:clickable="@{fairyTaleCreationViewModel.isWhoInputValid()}"
-                                    android:src="@{fairyTaleCreationViewModel.isWhoInputValid ? @drawable/btn_add_active : @drawable/btn_add_inactive}"
+                                    android:clickable="@{viewModel.isWhoInputValid()}"
+                                    android:src="@{viewModel.isWhoInputValid ? @drawable/btn_add_active : @drawable/btn_add_inactive}"
                                     android:background="@android:color/transparent"
                                     android:layout_gravity="center_vertical|end"
                                     />
@@ -211,7 +211,7 @@
                                     android:layout_width="match_parent"
                                     android:layout_height="match_parent"
                                     android:background="@drawable/chip_edit_box"
-                                    android:text="@={fairyTaleCreationViewModel.nameInput}"
+                                    android:text="@={viewModel.nameInput}"
                                     android:autofillHints="이름을 입력해 주세요."
                                     android:paddingStart="16dp"
                                     android:paddingEnd="4dp"
@@ -222,8 +222,8 @@
                                     android:layout_width="37dp"
                                     android:layout_height="37dp"
                                     android:layout_marginEnd="4dp"
-                                    android:clickable="@{fairyTaleCreationViewModel.isNameInputValid()}"
-                                    android:src="@{fairyTaleCreationViewModel.isNameInputValid() ? @drawable/btn_add_active : @drawable/btn_add_inactive}"
+                                    android:clickable="@{viewModel.isNameInputValid()}"
+                                    android:src="@{viewModel.isNameInputValid() ? @drawable/btn_add_active : @drawable/btn_add_inactive}"
                                     android:layout_gravity="center_vertical|end"
                                     />
                             </FrameLayout>
@@ -316,8 +316,8 @@
                                 android:layout_width="37dp"
                                 android:layout_height="37dp"
                                 android:layout_marginEnd="4dp"
-                                android:clickable="@{fairyTaleCreationViewModel.isWhereInputValid()}"
-                                android:src="@{fairyTaleCreationViewModel.isWhereInputValid() ? @drawable/btn_add_active : @drawable/btn_add_inactive}"
+                                android:clickable="@{viewModel.isWhereInputValid()}"
+                                android:src="@{viewModel.isWhereInputValid() ? @drawable/btn_add_active : @drawable/btn_add_inactive}"
                                 android:layout_gravity="center_vertical|end"
                                 />
                         </FrameLayout>
@@ -399,7 +399,7 @@
                                 android:layout_width="match_parent"
                                 android:layout_height="match_parent"
                                 android:background="@drawable/chip_edit_box"
-                                android:text="@{fairyTaleCreationViewModel.genreInput}"
+                                android:text="@{viewModel.genreInput}"
                                 android:paddingStart="16dp"
                                 android:paddingEnd="4dp"
                                 android:maxLength="15"
@@ -410,8 +410,8 @@
                                 android:layout_width="37dp"
                                 android:layout_height="37dp"
                                 android:layout_marginEnd="4dp"
-                                android:clickable="@{fairyTaleCreationViewModel.isGenreInputValid()}"
-                                android:src="@{fairyTaleCreationViewModel.isGenreInputValid() ? @drawable/btn_add_active : @drawable/btn_add_inactive}"
+                                android:clickable="@{viewModel.isGenreInputValid()}"
+                                android:src="@{viewModel.isGenreInputValid() ? @drawable/btn_add_active : @drawable/btn_add_inactive}"
                                 android:layout_gravity="center_vertical|end"
                                 />
                         </FrameLayout>

--- a/app/src/main/res/layout/fragment_fairy_tale_detail.xml
+++ b/app/src/main/res/layout/fragment_fairy_tale_detail.xml
@@ -6,7 +6,7 @@
 
     <data>
         <variable
-            name="fairyTaleDetailViewModel"
+            name="viewModel"
             type="com.sangik.iluvbook.fairytale.detail.viewmodel.FairyTaleDetailViewModel" />
     </data>
 
@@ -14,7 +14,6 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
-
 
         <androidx.viewpager2.widget.ViewPager2
             android:id="@+id/fairy_tale_viewpager"

--- a/app/src/main/res/layout/fragment_fairy_tale_detail_last_page.xml
+++ b/app/src/main/res/layout/fragment_fairy_tale_detail_last_page.xml
@@ -6,7 +6,7 @@
 
     <data>
         <variable
-            name="lastPageVm"
+            name="viewModel"
             type="com.sangik.iluvbook.fairytale.detail.viewmodel.FairyTaleLastPageViewModel" />
     </data>
 
@@ -21,7 +21,7 @@
             android:layout_width="250dp"
             android:layout_height="wrap_content"
             android:gravity="center"
-            android:text="@{lastPageVm.fairyTaleTitle}"
+            android:text="@{viewModel.fairyTaleTitle}"
             android:layout_marginTop="18dp"
             android:textAppearance="@style/fairytale_last_page_title"
             app:layout_constraintBottom_toTopOf="@id/fairy_tale_suggestion"

--- a/app/src/main/res/layout/fragment_fairy_tale_intro.xml
+++ b/app/src/main/res/layout/fragment_fairy_tale_intro.xml
@@ -6,7 +6,7 @@
 
     <data>
         <variable
-            name="fairyTaleIntroViewModel"
+            name="viewModel"
             type="com.sangik.iluvbook.fairytale.intro.viewmodel.FairyTaleIntroViewModel" />
     </data>
 
@@ -37,7 +37,7 @@
             android:id="@+id/fairytale_intro_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@{fairyTaleIntroViewModel.fairyTaleTitle}"
+            android:text="@{viewModel.fairyTaleTitle}"
             android:textAppearance="@style/fairytale_intro_title"
             android:layout_marginStart="16dp"
             android:layout_marginBottom="12dp"
@@ -66,7 +66,7 @@
             android:layout_marginBottom="40dp"
             app:layout_constraintBottom_toTopOf="@id/btn_read_fairytale"
             style="@style/fairytale_intro_summary_keyword"
-            android:text="@{fairyTaleIntroViewModel.fairyTaleSummary}"
+            android:text="@{viewModel.fairyTaleSummary}"
             app:layout_constraintLeft_toLeftOf="parent"/>
 
         <androidx.appcompat.widget.AppCompatImageButton

--- a/app/src/main/res/layout/fragment_fairy_tale_loading.xml
+++ b/app/src/main/res/layout/fragment_fairy_tale_loading.xml
@@ -9,7 +9,7 @@
         <import type="android.view.View" />
 
         <variable
-            name="loadingViewModel"
+            name="viewModel"
             type="com.sangik.iluvbook.fairytale.loading.viewmodel.FairyTaleLoadingViewModel" />
     </data>
 
@@ -35,7 +35,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:background="@drawable/check_icon"
-            android:visibility="@{loadingViewModel.isLoadingCompleted ? View.VISIBLE : View.GONE}"
+            android:visibility="@{viewModel.isLoadingCompleted ? View.VISIBLE : View.GONE}"
             android:layout_marginBottom="32dp"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
@@ -45,7 +45,7 @@
 
         <ImageView
             android:id="@+id/loading_banner"
-            android:visibility="@{loadingViewModel.isLoadingCompleted ? View.GONE : View.VISIBLE}"
+            android:visibility="@{viewModel.isLoadingCompleted ? View.GONE : View.VISIBLE}"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:background="@drawable/fairytale_loading"
@@ -64,7 +64,7 @@
             android:id="@+id/fairytale_loading_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@{loadingViewModel.isLoadingCompleted ? @string/fairytale_completed_title : @string/fairytale_loading_title}"
+            android:text="@{viewModel.isLoadingCompleted ? @string/fairytale_completed_title : @string/fairytale_loading_title}"
             android:textAppearance="@style/fairytale_last_page_title"
             android:gravity="center"
             android:layout_marginTop="38dp"
@@ -79,7 +79,7 @@
             android:id="@+id/fairytale_loading_body"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@{loadingViewModel.isLoadingCompleted ? @string/fairytale_completed_body : @string/fairytale_loading_body}"
+            android:text="@{viewModel.isLoadingCompleted ? @string/fairytale_completed_body : @string/fairytale_loading_body}"
             android:layout_marginTop="8dp"
             android:gravity="center"
             app:layout_constraintTop_toBottomOf="@id/fairytale_loading_title"
@@ -91,8 +91,8 @@
             android:id="@+id/btn_read_fairytale"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:visibility="@{loadingViewModel.isLoadingCompleted ? View.VISIBLE : View.GONE}"
-            android:clickable="@{loadingViewModel.isLoadingCompleted}"
+            android:visibility="@{viewModel.isLoadingCompleted ? View.VISIBLE : View.GONE}"
+            android:clickable="@{viewModel.isLoadingCompleted}"
             android:background="@drawable/btn_read_fairytale"
             android:layout_marginBottom="16dp"
             app:layout_constraintLeft_toLeftOf="parent"

--- a/app/src/main/res/layout/fragment_fairy_tale_page.xml
+++ b/app/src/main/res/layout/fragment_fairy_tale_page.xml
@@ -7,7 +7,7 @@
     <data>
         <import type="android.view.View"/>
         <variable
-            name="pageViewModel"
+            name="viewModel"
             type="com.sangik.iluvbook.fairytale.detail.viewmodel.FairyTalePageViewModel" />
 
         <variable
@@ -24,7 +24,7 @@
             android:id="@+id/fairy_tale_page_title"
             android:layout_width="300dp"
             android:layout_height="wrap_content"
-            android:text="@{pageViewModel.fairyTaleTitle}"
+            android:text="@{viewModel.fairyTaleTitle}"
             android:gravity="center"
             android:layout_marginTop="18dp"
             android:translationZ="2dp"
@@ -136,7 +136,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="@drawable/btn_translation"
-                android:onClick="@{() -> pageViewModel.toggleTranslateButton()}"
+                android:onClick="@{() -> viewModel.toggleTranslateButton()}"
                 android:layout_marginEnd="10dp"
                 android:contentDescription="@string/translate" />
 
@@ -145,7 +145,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="@drawable/btn_tts"
-                android:onClick="@{() -> pageViewModel.toggleTTSButton()}"
+                android:onClick="@{() -> viewModel.toggleTTSButton()}"
                 android:contentDescription="@string/volume" />
         </LinearLayout>
 
@@ -168,7 +168,7 @@
                 android:layout_height="wrap_content"
                 android:lineSpacingExtra="4sp"
                 android:textAppearance="@style/fairytale_detail_content"
-                android:text="@{pageViewModel.pageContent}"
+                android:text="@{viewModel.pageContent}"
                 />
 
         </ScrollView>

--- a/app/src/main/res/layout/fragment_fairy_tale_selection.xml
+++ b/app/src/main/res/layout/fragment_fairy_tale_selection.xml
@@ -6,7 +6,7 @@
 
     <data>
         <variable
-            name="selectionViewModel"
+            name="viewModel"
             type="com.sangik.iluvbook.fairytale.detail.viewmodel.FairyTaleSelectionViewModel" />
     </data>
 
@@ -32,7 +32,7 @@
                 android:id="@+id/fairy_tale_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@{selectionViewModel.fairyTaleTitle}"
+                android:text="@{viewModel.fairyTaleTitle}"
                 android:textAppearance="@style/fairytaleSelectionTitle"
                 android:layout_marginTop="18.5dp"
                 android:gravity="center"
@@ -93,7 +93,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="18dp"
                     android:layout_marginStart="8dp"
-                    android:text="@{selectionViewModel.options[0].optionTitle}"
+                    android:text="@{viewModel.options[0].optionTitle}"
                     android:gravity="center_vertical"
                     android:textAppearance="@style/fairyTaleOptionTitle"
                     app:layout_constraintLeft_toRightOf="@id/option_a"
@@ -106,7 +106,7 @@
                     android:layout_marginTop="10.5dp"
                     android:lineSpacingExtra="6dp"
                     android:textAppearance="@style/fairyTaleOptionContentOriginal"
-                    android:text="@{selectionViewModel.options[0].optionContent}"
+                    android:text="@{viewModel.options[0].optionContent}"
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toRightOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/fairy_tale_option_a_title"/>
@@ -118,7 +118,7 @@
                     android:layout_marginTop="2dp"
                     android:layout_marginBottom="16dp"
                     android:lineSpacingExtra="6dp"
-                    android:text="@{selectionViewModel.optionATranslated}"
+                    android:text="@{viewModel.optionATranslated}"
                     android:textAppearance="@style/fairyTaleOptionContentKr"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/fairy_tale_option_a_content_original"
@@ -156,7 +156,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="18dp"
                     android:layout_marginStart="8dp"
-                    android:text="@{selectionViewModel.options[1].optionTitle}"
+                    android:text="@{viewModel.options[1].optionTitle}"
                     android:gravity="center_vertical"
                     android:textAppearance="@style/fairyTaleOptionTitle"
                     app:layout_constraintLeft_toRightOf="@id/option_b"
@@ -169,7 +169,7 @@
                     android:layout_marginTop="10.5dp"
                     android:lineSpacingExtra="6dp"
                 android:textAppearance="@style/fairyTaleOptionContentOriginal"
-                    android:text="@{selectionViewModel.options[1].optionContent}"
+                    android:text="@{viewModel.options[1].optionContent}"
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toRightOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/fairy_tale_option_b_title"/>
@@ -182,7 +182,7 @@
                     android:layout_marginBottom="16dp"
                     android:lineSpacingExtra="6dp"
                     android:textAppearance="@style/fairyTaleOptionContentKr"
-                    android:text="@{selectionViewModel.optionBTranslated}"
+                    android:text="@{viewModel.optionBTranslated}"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/fairy_tale_option_b_content_original"
                     app:layout_constraintLeft_toLeftOf="parent"
@@ -219,7 +219,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="18dp"
                     android:layout_marginStart="8dp"
-                    android:text="@{selectionViewModel.options[2].optionTitle}"
+                    android:text="@{viewModel.options[2].optionTitle}"
                     android:gravity="center_vertical"
                     android:textAppearance="@style/fairyTaleOptionTitle"
                     app:layout_constraintLeft_toRightOf="@id/option_c"
@@ -232,7 +232,7 @@
                     android:layout_marginTop="10.5dp"
                     android:lineSpacingExtra="6dp"
                     android:textAppearance="@style/fairyTaleOptionContentOriginal"
-                    android:text="@{selectionViewModel.options[2].optionContent}"
+                    android:text="@{viewModel.options[2].optionContent}"
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toRightOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/fairy_tale_option_c_title"/>
@@ -245,7 +245,7 @@
                     android:layout_marginBottom="16dp"
                     android:lineSpacingExtra="6dp"
                     android:textAppearance="@style/fairyTaleOptionContentKr"
-                    android:text="@{selectionViewModel.optionCTranslated}"
+                    android:text="@{viewModel.optionCTranslated}"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/fairy_tale_option_c_content_original"
                     app:layout_constraintLeft_toLeftOf="parent"

--- a/app/src/main/res/layout/fragment_hangman.xml
+++ b/app/src/main/res/layout/fragment_hangman.xml
@@ -6,7 +6,7 @@
 
     <data>
         <variable
-            name="hangmanViewModel"
+            name="viewModel"
             type="com.sangik.iluvbook.hangman.game.viewmodel.HangmanViewModel" />
     </data>
 
@@ -79,7 +79,7 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_vertical|start"
                     android:layout_marginStart="70dp"
-                    android:text="@{hangmanViewModel.hint}"
+                    android:text="@{viewModel.hint}"
                     android:textAppearance="@style/HangmanGameHint" />
             </androidx.cardview.widget.CardView>
 

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -5,7 +5,7 @@
 
     <data>
         <variable
-            name="homeViewModel"
+            name="viewModel"
             type="com.sangik.iluvbook.home.viewmodel.HomeViewModel" />
     </data>
     <ScrollView
@@ -23,7 +23,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="50dp"
                 android:text="navigate to Onboarding !"
-                android:onClick="@{() -> homeViewModel.onMoveTextClicked()}"
+                android:onClick="@{() -> viewModel.onMoveTextClicked()}"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintRight_toRightOf="parent"
                 app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/fragment_intro_hangman.xml
+++ b/app/src/main/res/layout/fragment_intro_hangman.xml
@@ -6,7 +6,7 @@
 
     <data>
         <variable
-            name="introHangmanViewModel"
+            name="viewModel"
             type="com.sangik.iluvbook.hangman.intro.viewmodel.IntroHangmanViewModel" />
     </data>
 

--- a/app/src/main/res/layout/fragment_onboarding.xml
+++ b/app/src/main/res/layout/fragment_onboarding.xml
@@ -7,7 +7,7 @@
 
     <data>
         <variable
-            name="onboardingViewModel"
+            name="viewModel"
             type="com.sangik.iluvbook.fairytale.onboarding.viewmodel.OnboardingViewModel" />
     </data>
 


### PR DESCRIPTION
# 개요
### 목적
- 모든 Fragment에서 반복적으로 작성되던 `Data Binding` 및 `ViewModel 초기화 로직`을 `BaseFragment`로 통합하여 **코드 중복을 제거**하고, **유지보수성과 가독성**을 높였습니다.
- 또한, 각 Fragment가 UI 로직에만 집중할 수 있도록 구조를 단순화했습니다.

---

### 주요 변경점
#### - `BaseFragment` 생성
**공통 작업 통합**  
`BaseFragment`는 모든 Fragment에서 공통적으로 필요한 `데이터 바인딩 초기화`와 `ViewModel 생성 로직`을 처리합니다.  
이를 통해, 각 Fragment는 반복적인 코드를 제거하고 UI 관련 로직에만 집중할 수 있습니다.

**구조**  
- `@LayoutRes layoutResId`와 `viewModelClass`를 생성자로 받아, 필요한 레이아웃과 ViewModel 타입을 정의했습니다.
- `initView()`, `initObserver()`, `initListener()` 같은 메서드를 제공해, 각 Fragment에서 필요한 로직을 **오버라이드 가능**하도록 설계했습니다.

**적용 효과**  
각 Fragment에서 `Data Binding` 및 `ViewModel 초기화`와 관련된 반복 코드가 제거되었으며, 모든 Fragment의 코드가 약 20줄 감소하며 **가독성**과 **구조적 일관성**이 크게 향상되었습니다.



```kotlin
abstract class BaseFragment<T : ViewDataBinding, VM : ViewModel>(
    @LayoutRes private val layoutResId: Int,
    private val viewModelClass: KClass<VM>,
) : Fragment() {

    lateinit var binding: T
    val viewModel: VM by lazy {
        ViewModelProvider(this).get(viewModelClass.java)
    }

    override fun onCreateView(
        inflater: LayoutInflater, container: ViewGroup?,
        savedInstanceState: Bundle?
    ): View {
        binding = DataBindingUtil.inflate(inflater, layoutResId, container, false)
        binding.lifecycleOwner = viewLifecycleOwner
        binding.setVariable(BR.viewModel, viewModel)

        initView()
        initObserver()
        initListener()
        return binding.root
    }

    open fun initView() {}
    open fun initObserver() {}
    open fun initListener() {}
}
```

---


## 적용 중 발생한 트러블슈팅: ViewModel 범위 설정

#### 문제 정의
- 일부 Fragment에서 데이터를 공유하기 위해 Activity 범위의 ViewModel을 사용했습니다.  
  하지만 모든 Fragment에서 Activity 범위의 ViewModel을 사용할 필요가 있는 것은 아니었습니다.

- 예를 들어, `HangmanFragment`는 `IntroHangmanViewModel`과 데이터를 공유해야 하지만,  
  자체적으로 `HangmanViewModel`을 관리하는 로직도 필요합니다.  

- 이를 해결하기 위해, **ViewModel 범위를 어떻게 관리할지**에 대해 고민했습니다.

---

#### 검토 방안
1. **`isShared` 플래그 활용 방식**  
   - `BaseFragment`에서 `isShared` 와 같은 플래그를 받아, 필요한 경우 `requireActivity()`를 통해 ViewModel을 공유하도록 처리.  

2. **명시적 ViewModel 범위 설정 방식**  
   - 기본적으로는 `this`를 사용해 Fragment 전용 ViewModel을 관리.  
   - 필요한 경우에만 `requireActivity()`를 사용해 공유 데이터를 관리.  

---

#### 문제점 및 한계
- **`isShared` 플래그 활용 방식**
  - **장점**: 플래그를 통해 유연하게 Activity 범위를 설정할 수 있습니다.  

  - **단점**: 
    - `BaseFragment` 내부에서 ViewModel 범위를 제어하게 되어, 코드의 **책임 분리**가 불명확하다고 생각했습니다.  
    - 코드만 보고 어떤 Fragment가 Activity 범위를 참조하는지 명확히 파악하기 어렵습니다.  

- **명시적 ViewModel 범위 설정 방식**
  - **장점**: 
    - 각 Fragment에서 ViewModel 범위를 직접 명시하므로, **책임 분리와 코드의 직관성**이 유지됩니다.  

    - Activity 범위를 필요로 하지 않는 Fragment에 적용하지 않으므로, 코드의 복잡성이 줄어듭니다.  

---

#### 최종 결정 및 이유
- **두 번째 방식을 채택**했습니다.  

  - Fragment 전용 데이터와 Activity 간 공유 데이터를 명확히 분리할 수 있었습니다.  

  - 필요할 때만 `requireActivity()`를 호출하므로, 코드의 직관성과 유지보수성이 향상되었습니다.
